### PR TITLE
C++: Simplify automaticVariableAddressEscapes

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -247,15 +247,11 @@ predicate resultEscapesNonReturn(Instruction instr) {
  * domain of the analysis.
  */
 private predicate automaticVariableAddressEscapes(IRAutomaticVariable var) {
-  exists(FunctionIR funcIR |
-    funcIR = var.getEnclosingFunctionIR() and
-    // The variable's address escapes if the result of any
-    // VariableAddressInstruction that computes the variable's address escapes.
-    exists(VariableAddressInstruction instr |
-      instr.getEnclosingFunctionIR() = funcIR and
-      instr.getVariable() = var and
-      resultEscapesNonReturn(instr)
-    )
+  // The variable's address escapes if the result of any
+  // VariableAddressInstruction that computes the variable's address escapes.
+  exists(VariableAddressInstruction instr |
+    instr.getVariable() = var and
+    resultEscapesNonReturn(instr)
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -247,15 +247,11 @@ predicate resultEscapesNonReturn(Instruction instr) {
  * domain of the analysis.
  */
 private predicate automaticVariableAddressEscapes(IRAutomaticVariable var) {
-  exists(FunctionIR funcIR |
-    funcIR = var.getEnclosingFunctionIR() and
-    // The variable's address escapes if the result of any
-    // VariableAddressInstruction that computes the variable's address escapes.
-    exists(VariableAddressInstruction instr |
-      instr.getEnclosingFunctionIR() = funcIR and
-      instr.getVariable() = var and
-      resultEscapesNonReturn(instr)
-    )
+  // The variable's address escapes if the result of any
+  // VariableAddressInstruction that computes the variable's address escapes.
+  exists(VariableAddressInstruction instr |
+    instr.getVariable() = var and
+    resultEscapesNonReturn(instr)
   )
 }
 


### PR DESCRIPTION
The `automaticVariableAddressEscapes` predicate got join-ordered badly in its `unaliased_ssa` version. These are the tuple counts on Wireshark, where one pipeline step is seen to have 716 million tuples:

```
[2019-03-02 11:29:41] (42s) Starting to evaluate predicate AliasAnalysis::automaticVariableAddressEscapes#2#f
[2019-03-02 11:30:06] (67s) Tuple counts:
                      353419    ~0%      {1} r1 = JOIN project#Instruction::VariableAddressInstruction#class#2#ff WITH AliasAnalysis::resultEscapesNonReturn#2#f ON project#Instruction::VariableAddressInstruction#class#2#ff.<0>=AliasAnalysis::resultEscapesNonReturn#2#f.<0> OUTPUT FIELDS {AliasAnalysis::resultEscapesNonReturn#2#f.<0>}
                      353419    ~0%      {2} r2 = JOIN r1 WITH IRConstruction::Cached::getInstructionEnclosingFunctionIR#ff@staged_ext ON r1.<0>=IRConstruction::Cached::getInstructionEnclosingFunctionIR#ff@staged_ext.<0> OUTPUT FIELDS {IRConstruction::Cached::getInstructionEnclosingFunctionIR#ff@staged_ext.<1>,r1.<0>}
                      353419    ~0%      {2} r3 = JOIN r2 WITH FunctionIR::FunctionIR::getFunction_dispred#3#ff ON r2.<0>=FunctionIR::FunctionIR::getFunction_dispred#3#ff.<0> OUTPUT FIELDS {FunctionIR::FunctionIR::getFunction_dispred#3#ff.<1>,r2.<1>}
                      716040298 ~0%      {2} r4 = JOIN r3 WITH IRVariable::IRVariable#class#3#ff_10#join_rhs ON r3.<0>=IRVariable::IRVariable#class#3#ff_10#join_rhs.<0> OUTPUT FIELDS {IRVariable::IRVariable#class#3#ff_10#join_rhs.<1>,r3.<1>}
                      4480139   ~0%      {2} r5 = JOIN r4 WITH IRVariable::IRAutomaticVariable#class#3#ff ON r4.<0>=IRVariable::IRAutomaticVariable#class#3#ff.<0> OUTPUT FIELDS {r4.<1>,r4.<0>}
                      66760     ~91%     {1} r6 = JOIN r5 WITH Instruction::VariableInstruction::getVariable_dispred#2#ff ON r5.<0>=Instruction::VariableInstruction::getVariable_dispred#2#ff.<0> AND r5.<1>=Instruction::VariableInstruction::getVariable_dispred#2#ff.<1> OUTPUT FIELDS {r5.<1>}
                                         return r6
[2019-03-02 11:30:06] (67s)  >>> Relation AliasAnalysis::automaticVariableAddressEscapes#2#f: 35531 rows using 0 MB
```

The predicate contained a cyclic join, which is always hard to optimize. I couldn't see a reason to join the `FunctionIR`, so I removed that part. The predicate is now fast, and there are no changes in the tests.