### PR TITLE
C++: Exclude global flow from the XXE query for now.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/cpp/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -43,6 +43,12 @@ class XXEConfiguration extends DataFlow::Configuration {
     // flowstate value.
     node.asConvertedExpr().(XxeFlowStateTransformer).transform(flowstate) != flowstate
   }
+
+  override predicate isBarrier(DataFlow::Node node) {
+    // the above `isBarrier` definition isn't working well on global variables,
+    // so block all accesses to globals to avoid spurious results.
+    node.asExpr().(Access).getTarget() instanceof GlobalVariable
+  }
 }
 
 from XXEConfiguration conf, DataFlow::PathNode source, DataFlow::PathNode sink

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/XXE.expected
@@ -2,26 +2,11 @@ edges
 | tests2.cpp:20:17:20:31 | SAXParser output argument | tests2.cpp:22:2:22:2 | p |
 | tests2.cpp:33:17:33:31 | SAXParser output argument | tests2.cpp:37:2:37:2 | p |
 | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p |
-| tests3.cpp:35:16:35:20 | p_3_3 | tests3.cpp:38:2:38:6 | p_3_3 |
-| tests3.cpp:35:24:35:56 | Store | tests3.cpp:35:16:35:20 | p_3_3 |
-| tests3.cpp:35:24:35:56 | call to createXMLReader | tests3.cpp:35:24:35:56 | Store |
-| tests3.cpp:41:16:41:20 | p_3_4 | tests3.cpp:45:2:45:6 | p_3_4 |
-| tests3.cpp:41:24:41:56 | Store | tests3.cpp:41:16:41:20 | p_3_4 |
-| tests3.cpp:41:24:41:56 | call to createXMLReader | tests3.cpp:41:24:41:56 | Store |
-| tests3.cpp:48:16:48:20 | p_3_5 | tests3.cpp:56:2:56:6 | p_3_5 |
-| tests3.cpp:48:24:48:56 | Store | tests3.cpp:48:16:48:20 | p_3_5 |
-| tests3.cpp:48:24:48:56 | call to createXMLReader | tests3.cpp:48:24:48:56 | Store |
 | tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p |
 | tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p |
 | tests5.cpp:27:25:27:38 | call to createLSParser | tests5.cpp:29:2:29:2 | p |
 | tests5.cpp:40:25:40:38 | call to createLSParser | tests5.cpp:43:2:43:2 | p |
 | tests5.cpp:55:25:55:38 | call to createLSParser | tests5.cpp:59:2:59:2 | p |
-| tests5.cpp:63:14:63:17 | g_p1 | tests5.cpp:76:2:76:5 | g_p1 |
-| tests5.cpp:63:21:63:24 | g_p2 | tests5.cpp:77:2:77:5 | g_p2 |
-| tests5.cpp:67:2:67:32 | Store | tests5.cpp:63:14:63:17 | g_p1 |
-| tests5.cpp:67:17:67:30 | call to createLSParser | tests5.cpp:67:2:67:32 | Store |
-| tests5.cpp:70:2:70:32 | Store | tests5.cpp:63:21:63:24 | g_p2 |
-| tests5.cpp:70:17:70:30 | call to createLSParser | tests5.cpp:70:2:70:32 | Store |
 | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p |
 | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p |
 | tests5.cpp:83:2:83:2 | p | tests5.cpp:85:2:85:2 | p |
@@ -61,18 +46,6 @@ nodes
 | tests2.cpp:37:2:37:2 | p | semmle.label | p |
 | tests3.cpp:23:21:23:53 | call to createXMLReader | semmle.label | call to createXMLReader |
 | tests3.cpp:25:2:25:2 | p | semmle.label | p |
-| tests3.cpp:35:16:35:20 | p_3_3 | semmle.label | p_3_3 |
-| tests3.cpp:35:24:35:56 | Store | semmle.label | Store |
-| tests3.cpp:35:24:35:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:38:2:38:6 | p_3_3 | semmle.label | p_3_3 |
-| tests3.cpp:41:16:41:20 | p_3_4 | semmle.label | p_3_4 |
-| tests3.cpp:41:24:41:56 | Store | semmle.label | Store |
-| tests3.cpp:41:24:41:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:45:2:45:6 | p_3_4 | semmle.label | p_3_4 |
-| tests3.cpp:48:16:48:20 | p_3_5 | semmle.label | p_3_5 |
-| tests3.cpp:48:24:48:56 | Store | semmle.label | Store |
-| tests3.cpp:48:24:48:56 | call to createXMLReader | semmle.label | call to createXMLReader |
-| tests3.cpp:56:2:56:6 | p_3_5 | semmle.label | p_3_5 |
 | tests3.cpp:60:21:60:53 | call to createXMLReader | semmle.label | call to createXMLReader |
 | tests3.cpp:63:2:63:2 | p | semmle.label | p |
 | tests3.cpp:67:21:67:53 | call to createXMLReader | semmle.label | call to createXMLReader |
@@ -88,14 +61,6 @@ nodes
 | tests5.cpp:43:2:43:2 | p | semmle.label | p |
 | tests5.cpp:55:25:55:38 | call to createLSParser | semmle.label | call to createLSParser |
 | tests5.cpp:59:2:59:2 | p | semmle.label | p |
-| tests5.cpp:63:14:63:17 | g_p1 | semmle.label | g_p1 |
-| tests5.cpp:63:21:63:24 | g_p2 | semmle.label | g_p2 |
-| tests5.cpp:67:2:67:32 | Store | semmle.label | Store |
-| tests5.cpp:67:17:67:30 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:70:2:70:32 | Store | semmle.label | Store |
-| tests5.cpp:70:17:70:30 | call to createLSParser | semmle.label | call to createLSParser |
-| tests5.cpp:76:2:76:5 | g_p1 | semmle.label | g_p1 |
-| tests5.cpp:77:2:77:5 | g_p2 | semmle.label | g_p2 |
 | tests5.cpp:81:25:81:38 | call to createLSParser | semmle.label | call to createLSParser |
 | tests5.cpp:83:2:83:2 | p | semmle.label | p |
 | tests5.cpp:83:2:83:2 | p | semmle.label | p |
@@ -143,9 +108,6 @@ subpaths
 | tests2.cpp:22:2:22:2 | p | tests2.cpp:20:17:20:31 | SAXParser output argument | tests2.cpp:22:2:22:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:20:17:20:31 | SAXParser output argument | XML parser |
 | tests2.cpp:37:2:37:2 | p | tests2.cpp:33:17:33:31 | SAXParser output argument | tests2.cpp:37:2:37:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests2.cpp:33:17:33:31 | SAXParser output argument | XML parser |
 | tests3.cpp:25:2:25:2 | p | tests3.cpp:23:21:23:53 | call to createXMLReader | tests3.cpp:25:2:25:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:23:21:23:53 | call to createXMLReader | XML parser |
-| tests3.cpp:38:2:38:6 | p_3_3 | tests3.cpp:35:24:35:56 | call to createXMLReader | tests3.cpp:38:2:38:6 | p_3_3 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:35:24:35:56 | call to createXMLReader | XML parser |
-| tests3.cpp:45:2:45:6 | p_3_4 | tests3.cpp:41:24:41:56 | call to createXMLReader | tests3.cpp:45:2:45:6 | p_3_4 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:41:24:41:56 | call to createXMLReader | XML parser |
-| tests3.cpp:56:2:56:6 | p_3_5 | tests3.cpp:48:24:48:56 | call to createXMLReader | tests3.cpp:56:2:56:6 | p_3_5 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:48:24:48:56 | call to createXMLReader | XML parser |
 | tests3.cpp:63:2:63:2 | p | tests3.cpp:60:21:60:53 | call to createXMLReader | tests3.cpp:63:2:63:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:60:21:60:53 | call to createXMLReader | XML parser |
 | tests3.cpp:70:2:70:2 | p | tests3.cpp:67:21:67:53 | call to createXMLReader | tests3.cpp:70:2:70:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests3.cpp:67:21:67:53 | call to createXMLReader | XML parser |
 | tests4.cpp:26:34:26:48 | (int)... | tests4.cpp:26:34:26:48 | (int)... | tests4.cpp:26:34:26:48 | (int)... | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests4.cpp:26:34:26:48 | (int)... | XML parser |
@@ -156,8 +118,6 @@ subpaths
 | tests5.cpp:29:2:29:2 | p | tests5.cpp:27:25:27:38 | call to createLSParser | tests5.cpp:29:2:29:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:27:25:27:38 | call to createLSParser | XML parser |
 | tests5.cpp:43:2:43:2 | p | tests5.cpp:40:25:40:38 | call to createLSParser | tests5.cpp:43:2:43:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:40:25:40:38 | call to createLSParser | XML parser |
 | tests5.cpp:59:2:59:2 | p | tests5.cpp:55:25:55:38 | call to createLSParser | tests5.cpp:59:2:59:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:55:25:55:38 | call to createLSParser | XML parser |
-| tests5.cpp:76:2:76:5 | g_p1 | tests5.cpp:67:17:67:30 | call to createLSParser | tests5.cpp:76:2:76:5 | g_p1 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:67:17:67:30 | call to createLSParser | XML parser |
-| tests5.cpp:77:2:77:5 | g_p2 | tests5.cpp:70:17:70:30 | call to createLSParser | tests5.cpp:77:2:77:5 | g_p2 | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:70:17:70:30 | call to createLSParser | XML parser |
 | tests5.cpp:83:2:83:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:83:2:83:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
 | tests5.cpp:89:2:89:2 | p | tests5.cpp:81:25:81:38 | call to createLSParser | tests5.cpp:89:2:89:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests5.cpp:81:25:81:38 | call to createLSParser | XML parser |
 | tests.cpp:17:2:17:2 | p | tests.cpp:15:23:15:43 | XercesDOMParser output argument | tests.cpp:17:2:17:2 | p | This $@ is not configured to prevent an XML external entity (XXE) attack. | tests.cpp:15:23:15:43 | XercesDOMParser output argument | XML parser |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests3.cpp
@@ -35,14 +35,14 @@ void test3_2(InputSource &data) {
 SAX2XMLReader *p_3_3 = XMLReaderFactory::createXMLReader();
 
 void test3_3(InputSource &data) {
-	p_3_3->parse(data); // BAD (parser not correctly configured)
+	p_3_3->parse(data); // BAD (parser not correctly configured) [NOT DETECTED]
 }
 
 SAX2XMLReader *p_3_4 = XMLReaderFactory::createXMLReader();
 
 void test3_4(InputSource &data) {
 	p_3_4->setFeature(XMLUni::fgXercesDisableDefaultEntityResolution, true);
-	p_3_4->parse(data); // GOOD [FALSE POSITIVE]
+	p_3_4->parse(data); // GOOD
 }
 
 SAX2XMLReader *p_3_5 = XMLReaderFactory::createXMLReader();
@@ -53,7 +53,7 @@ void test3_5_init() {
 
 void test3_5(InputSource &data) {
 	test3_5_init();
-	p_3_5->parse(data); // GOOD [FALSE POSITIVE]
+	p_3_5->parse(data); // GOOD
 }
 
 void test3_6(InputSource &data) {

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests5.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-611/tests5.cpp
@@ -73,8 +73,8 @@ void test5_6_init() {
 void test5_6() {
 	test5_6_init();
 
-	g_p1->parse(*g_data); // GOOD [FALSE POSITIVE]
-	g_p2->parse(*g_data); // BAD (parser not correctly configured)
+	g_p1->parse(*g_data); // GOOD
+	g_p2->parse(*g_data); // BAD (parser not correctly configured) [NOT DETECTED]
 }
 
 void test5_7(DOMImplementationLS *impl, InputSource &data) {


### PR DESCRIPTION
Proposed workaround for false positive test results in the XXE query introduced by https://github.com/github/codeql/pull/8596 .  Its a bit of a shame we lose the two newly found good results for this query as well.  I'm open to suggestions on that.