### PR TITLE
Swift: Fix type pruning performance.

### DIFF
--- a/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
+++ b/swift/ql/lib/codeql/swift/dataflow/internal/DataFlowPrivate.qll
@@ -1192,8 +1192,8 @@ predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   )
   or
   exists(TupleType tuple1, TupleType tuple2 |
-    stripType(t1.asType()) = pragma[only_bind_out](tuple1) and
-    stripType(t2.asType()) = pragma[only_bind_into](tuple2) and
+    stripType(t1.asType()) = tuple1 and
+    stripType(t2.asType()) = tuple2 and
     compatibleTuples(tuple1, tuple2)
   )
   or
@@ -1237,7 +1237,7 @@ predicate isAnyOrUnboundType(Type t) {
   )
 }
 
-pragma[noinline]
+pragma[inline]
 predicate compatibleTuples(TupleType tuple1, TupleType tuple2) {
   tuple1.getNumberOfTypes() = tuple2.getNumberOfTypes() and
   tuple1.getType(0) = tuple2.getType(0) and
@@ -1266,14 +1266,7 @@ Type stripType(Type t) {
     result = stripType(iot.getObjectType().getCanonicalType())
   )
   or
-  exists(TupleType labeled, TupleType unlabeled |
-    labeled = t and
-    forall(int index | index in [0 .. labeled.getNumberOfTypes() - 1] |
-      labeled.getType(index) = unlabeled.getType(index) and
-      not exists(unlabeled.getName(index))
-    ) and
-    result = unlabeled
-  )
+  result = t.(TupleType).asUnlabeled()
   or
   not exists(BoundGenericEnumType optional |
     optional = t and

--- a/swift/ql/lib/codeql/swift/elements/type/TupleType.qll
+++ b/swift/ql/lib/codeql/swift/elements/type/TupleType.qll
@@ -6,4 +6,13 @@ private import codeql.swift.generated.type.TupleType
  * (Int, String)
  * ```
  */
-class TupleType extends Generated::TupleType { }
+class TupleType extends Generated::TupleType {
+  /**
+   * Gets the type that is this tuple type with any element labels removed.
+   */
+  TupleType asUnlabeled() {
+    result.getNumberOfTypes() = this.getNumberOfTypes() and
+    not exists(int index | result.getType(index) != this.getType(index)) and
+    not exists(result.getName(_))
+  }
+}


### PR DESCRIPTION
@rdmarsh2 - this is what I came up with trying to fix the performance problem in the type pruning PR.  I was suspicious of `stripType` for `TupleType`s in particular, so I tried to clean that up a bit and removed some tags I wasn't sure were actually helping.

In the two test cases I looked at performance is back to around where it was before type pruning was added, and the most expensive predicates list looks normal again.  Guess I'll run DCA on here for a more detailed report.

The dataflow test results are unaffected, but I haven't tested any deeper than that.  I am thus not confident this change is correct.

